### PR TITLE
Negated Environment Bug Fixes and Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ jobs:
 apply configuration? [yN]: 
 ```
 ### Setting a Pipeline for Multiple Environments.
-Specifying the `--all` flag when using the `--set-pipeline` command will attempt to set the pipeline for all environments, except for `common`.
+Specifying the `--all` flag when using the `--set-pipeline` command will attempt to set the pipeline for all environments, except for defined within the `.cck.yml` under `ignore_environments: []`.  By default, the `common` environment has been added for you. 
 
 For this to work, every `target-environment` must have all the same var yaml files, content files etc. otherwise the pipeline will work for some environments, not others.  
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="concoursekit",
     author="Anthony Hawkins",
     author_email="ahawkins.mail@gmail.com",
-    version="0.1.0",
+    version="0.1.1",
     description="A Concourse CI Pipeline Generator Utility.",
     keywords=["concourse", "yaml generator", "pipeline manager", "ci", "cd"],
     license="MIT",

--- a/tests/.cck.yml
+++ b/tests/.cck.yml
@@ -22,3 +22,8 @@ pipelines_test_dir: pipeline_tests
 
 # The directory to use for target-environments
 target_environments_dir: target-environments
+
+# Environments to ignore when setting pipelines
+ignore_environments:
+- common
+- trusted-CAs


### PR DESCRIPTION
Fixing bug where negated environment logic would cause an exception if the negated environment was present as a sub directory in one environment, but not others.

Added the capability to declare ignored environments for directories within environment directories which should not be considered environment or should be negated automatically